### PR TITLE
Django 1.8: 1.7/1.8 style migrations, Django version adjusted.

### DIFF
--- a/aldryn_apphook_reload/migrations/0001_initial.py
+++ b/aldryn_apphook_reload/migrations/0001_initial.py
@@ -1,0 +1,20 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import models, migrations
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+    ]
+
+    operations = [
+        migrations.CreateModel(
+            name='UrlconfRevision',
+            fields=[
+                ('id', models.AutoField(verbose_name='ID', serialize=False, auto_created=True, primary_key=True)),
+                ('revision', models.CharField(max_length=255)),
+            ],
+        ),
+    ]

--- a/setup.py
+++ b/setup.py
@@ -20,7 +20,7 @@ setup(
     include_package_data=True,
     zip_safe=False,
     install_requires=(
-        'Django>=1.6,<1.8',
+        'Django>=1.6,<1.9',
         'South>=1.0.1,<2',
     ),
     classifiers = [


### PR DESCRIPTION
Bump version of Django in setup py to allow self and other addons to support Django 1.8
New 1.7/1.8 style migration
